### PR TITLE
support language code postfix (e.g. zh-CN)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ srcs = $(filter-out $(WHITELIST),$(shell find examples -name '*.rs'))
 all:
 	./setup-stage.sh
 	$(RUSTC) src/update.rs --out-dir bin
-	bin/update
+	bin/update zh-CN
 
 book:
 	cd stage && $(GITBOOK) build

--- a/examples/panic/input.md
+++ b/examples/panic/input.md
@@ -5,18 +5,18 @@ resources *owned* by the task by calling the destructor of all its objects.
 Since we are dealing with programs with only one task, `panic!` will cause the
 program to report the failure message and exit.
 
-{fail.play}
+{panic.play}
 
 Let's check that `panic!` doesn't leak memory.
 
 ```
-$ rustc fail.rs && valgrind ./fail
+$ rustc panic.rs && valgrind ./panic
 ==2614== Memcheck, a memory error detector
 ==2614== Copyright (C) 2002-2013, and GNU GPL'd, by Julian Seward et al.
 ==2614== Using Valgrind-3.9.0 and LibVEX; rerun with -h for copyright info
-==2614== Command: ./fail
+==2614== Command: ./panic
 ==2614==
-task '<main>' failed at 'division by zero', fail.rs:5
+task '<main>' failed at 'division by zero', panic.rs:5
 ==2614==
 ==2614== HEAP SUMMARY:
 ==2614==     in use at exit: 0 bytes in 0 blocks

--- a/examples/structure.json
+++ b/examples/structure.json
@@ -68,7 +68,7 @@
   { "id": "enum", "title": "Enums", "children": [
       { "id": "c-like", "title": "C-like", "children": null }
   ] },
-  { "id": "fail", "title": "`panic!`", "children": null },
+  { "id": "panic", "title": "`panic!`", "children": null },
   { "id": "option", "title": "`Option`", "children": null },
   { "id": "array", "title": "Arrays and Slices", "children": null },
   { "id": "trait", "title": "Traits", "children": [

--- a/src/example.rs
+++ b/src/example.rs
@@ -37,14 +37,16 @@ impl Example {
                    number: Vec<uint>,
                    tx: Sender<(Vec<uint>, String)>,
                    indent: uint,
-                   prefix: String)
+                   prefix: String,
+                   postfix: String)
     {
         let id = self.id.as_slice();
         let prefix = prefix.as_slice();
+        let postfix = postfix.as_slice();
         let title = self.title.as_slice();
 
         let entry =
-            match Markdown::process(number.as_slice(), id, title, prefix) {
+            match Markdown::process(number.as_slice(), id, title, prefix, postfix) {
                 Ok(_) => {
                     let md = if prefix.as_slice().is_whitespace() {
                         format!("{}.md", id)
@@ -85,7 +87,8 @@ impl Example {
                     example.process(number,
                                     tx,
                                     indent + 1,
-                                    prefix);
+                                    prefix,
+                                    postfix.to_string());
                 }
             },
         }

--- a/src/markdown.rs
+++ b/src/markdown.rs
@@ -8,10 +8,10 @@ pub struct Markdown<'a, 'b> {
 }
 
 impl<'a, 'b> Markdown<'a, 'b> {
-    pub fn process(number: &[uint], id: &'a str, title: &str, prefix: &'b str)
-        -> Result<(), String>
+    pub fn process(number: &[uint], id: &'a str, title: &str,
+        prefix: &'b str, postfix: &str) -> Result<(), String>
     {
-        let mut mkd = try!(Markdown::new(number, id, title, prefix));
+        let mut mkd = try!(Markdown::new(number, id, title, prefix, postfix));
 
         try!(mkd.insert_sources());
         try!(mkd.insert_outputs());
@@ -21,11 +21,24 @@ impl<'a, 'b> Markdown<'a, 'b> {
         Ok(())
     }
 
-    fn new(number: &[uint], id: &'a str, title: &str, prefix: &'b str)
+    fn new(number: &[uint], id: &'a str, title: &str, prefix: &'b str, postfix: &str)
         -> Result<Markdown<'a, 'b>, String>
     {
-        let path = Path::new(format!("examples/{}/{}/input.md", prefix, id));
-        let body = try!(file::read(&path));
+        let path = Path::new(format!("examples/{}/{}/input{}.md", prefix, id, postfix));
+
+        let body = if postfix.len() == 0 {
+            try!(file::read(&path))
+        } else {
+            match file::read(&path) {
+                Ok(body) => body,
+                Err(_)   => {
+                    let no_postfix_path = Path::new(format!("examples/{}/{}/input.md", prefix, id));
+                    println!("try open: {}", no_postfix_path.display());
+                    try!(file::read(&no_postfix_path))
+                }
+            }
+        };
+
         let version = number.iter().map(|x| {
             format!("{}", x)
         }).collect::<Vec<String>>().connect(".");

--- a/src/update.rs
+++ b/src/update.rs
@@ -6,6 +6,7 @@ extern crate regex;
 extern crate regex_macros;
 extern crate serialize;
 
+use std::os;
 use example::Example;
 
 mod example;
@@ -14,6 +15,13 @@ mod markdown;
 mod playpen;
 
 fn main() {
+    let args = os::args();
+    let mut postfix = String::new();
+    if args.len() > 1 && !args[1].as_slice().is_empty() {
+        postfix.push('_');
+        postfix.push_str(args[1].as_slice()); // language code such as "zh-CN"
+    }
+
     let examples = Example::get_list();
     let (tx, rx) = channel();
 
@@ -21,9 +29,10 @@ fn main() {
     for (i, example) in examples.into_iter().enumerate() {
         let tx = tx.clone();
         let count = example.count();
+        let postfix = postfix.clone();
 
         spawn(proc() {
-            example.process(vec!(i + 1), tx, 0, String::new());
+            example.process(vec!(i + 1), tx, 0, String::new(), postfix);
         });
 
         nexamples += count;


### PR DESCRIPTION
支持多语言文档。默认生成中文文档（如果input_zh-CN.md文件不存在，自动读取对应的英文input.md）。
