### PR TITLE
fix css: enlarge `margin-bottom` of `#active-code`

### DIFF
--- a/node_modules/gitbook-plugin-rust-playpen/book/editor.css
+++ b/node_modules/gitbook-plugin-rust-playpen/book/editor.css
@@ -7,6 +7,7 @@
   border-radius: 4px;
   background-color: #FDFDFD;
   border: 1px solid #CCC;
+  margin-bottom:20px;
 }
 
 #editor {


### PR DESCRIPTION
增大代码框与下面文本的空白，保持与代码框上面的空白一致，外观上更协调。

感谢 @bywayboy 
